### PR TITLE
Harden operator approvals, make backend strict, and enforce manifest & WSGI production requirements

### DIFF
--- a/aurora_nexus_v3/core/hybrid_orchestrator.py
+++ b/aurora_nexus_v3/core/hybrid_orchestrator.py
@@ -387,6 +387,19 @@ class HybridOrchestrator:
     async def _validate_manifests(self):
         """Validate loaded manifests for consistency"""
         validation_errors = []
+
+        if len(self.tiers) != self.TIER_COUNT:
+            validation_errors.append(
+                f"Tiers count mismatch: expected {self.TIER_COUNT}, got {len(self.tiers)}"
+            )
+        if len(self.execution_methods) != self.AEM_COUNT:
+            validation_errors.append(
+                f"AEM count mismatch: expected {self.AEM_COUNT}, got {len(self.execution_methods)}"
+            )
+        if len(self.modules) < self.MODULE_COUNT:
+            validation_errors.append(
+                f"Module count mismatch: expected at least {self.MODULE_COUNT}, got {len(self.modules)}"
+            )
         
         for tier_id, tier in self.tiers.items():
             for dep in tier.get("dependencies", []):
@@ -399,9 +412,10 @@ class HybridOrchestrator:
                     validation_errors.append(f"Module {mod_id} has missing dependency: {dep}")
         
         if validation_errors:
-            self.logger.warning(f"Manifest validation found {len(validation_errors)} warnings")
-            for error in validation_errors[:5]:
-                self.logger.warning(f"  - {error}")
+            self.logger.error(f"Manifest validation found {len(validation_errors)} issues")
+            for error in validation_errors[:10]:
+                self.logger.error(f"  - {error}")
+            raise RuntimeError("Manifest validation failed; required components missing.")
         else:
             self.logger.info("Manifest validation passed successfully")
     

--- a/packs/pack03_os_edge/automotive/ecu_suggestor.py
+++ b/packs/pack03_os_edge/automotive/ecu_suggestor.py
@@ -1,17 +1,26 @@
 #!/usr/bin/env python3
 """
 Tool for an operator to list suggestions and apply them after manual review.
-This tool simulates the human approval flow: operator signs the suggestion with a passphrase (not real crypto in this stub).
-In production: integrate HSM / GPG signing + Luminar Nexus v3 human-approval workflow.
+Approvals are signed with HMAC using AURORA_OPERATOR_SIGNING_KEY to provide
+tamper-evident audit records. For HSM/GPG, replace the signing implementation.
 """
 
-import os, json, getpass
+import os, json, hmac, hashlib
 from pathlib import Path
 
 SUGGEST_DIR = Path("automotive/suggestions")
 APPLIED_DIR = Path("automotive/applied")
 SUGGEST_DIR.mkdir(parents=True, exist_ok=True)
 APPLIED_DIR.mkdir(parents=True, exist_ok=True)
+
+def _require_operator_key():
+    key = os.getenv("AURORA_OPERATOR_SIGNING_KEY")
+    if not key:
+        raise RuntimeError("AURORA_OPERATOR_SIGNING_KEY must be set to approve suggestions.")
+    return key
+
+def _sign_payload(payload: bytes, key: str) -> str:
+    return hmac.new(key.encode("utf-8"), payload, hashlib.sha256).hexdigest()
 
 def list_suggestions():
     return sorted(SUGGEST_DIR.glob("*.json"))
@@ -23,9 +32,18 @@ def apply_suggestion(path:Path):
     if confirm != "YES":
         print("aborted")
         return
-    # In real: operator signs; here we just move file to applied and log
+    operator = input("Operator name: ").strip() or "operator"
+    key = _require_operator_key()
+    content = path.read_text()
+    payload = json.dumps(
+        {"file": path.name, "operator": operator, "content": content},
+        sort_keys=True,
+    ).encode("utf-8")
+    signature = _sign_payload(payload, key)
+    approval = {"operator": operator, "signature": signature}
     out = APPLIED_DIR / path.name
     path.rename(out)
+    (APPLIED_DIR / f"{path.stem}.sig.json").write_text(json.dumps(approval, indent=2))
     print("Moved to applied:", out)
     # real execution: call safe executor or hand off to certified toolchain
     return out


### PR DESCRIPTION
### Motivation
- Fix critical approval and audit weaknesses by replacing informal/stub approval flows with tamper-evident signing and explicit operator gating. 
- Prevent the AI backend from silently returning stub/echo responses when the Aurora core is not initialized so availability problems are visible and fail fast. 
- Ensure the orchestrator only proceeds when the full manifests are present (188 tiers, 66 AEMs, 550+ modules) to avoid partial/hidden runtime behavior. 
- Require a production WSGI (waitress) for Nexus V2 by default to avoid accidentally running a dev server in production environments. 

### Description
- Require `AURORA_OPERATOR_SIGNING_KEY` and add HMAC-SHA256 signing/verification for operator approvals in `integration/updater/updater_service.py`, and write `.approved` approval records with operator, ts, and signature. 
- Add HMAC signing for ECU suggestion application in `packs/pack03_os_edge/automotive/ecu_suggestor.py` and write signature files alongside applied suggestions for tamper-evident auditability. 
- Make the AI backend (`aurora_backend/main.py`) strict when the core is unavailable by returning `503 Service Unavailable` on `/api/chat`, closing websocket connections with an explanatory message, and logging core unavailability as an error. 
- Enforce manifest counts during orchestrator validation in `aurora_nexus_v3/core/hybrid_orchestrator.py` (fail initialization if tiers/AEMs/modules are missing) and raise a runtime error on validation failure. 
- Require `waitress` for `tools/luminar_nexus_v2.py` WSGI server by default and only allow the dev fallback when `AURORA_ALLOW_DEV_SERVER=1` is explicitly set. 

### Testing
- No automated tests were executed for these changes in this rollout (no CI/test runs performed). 
- Recommended automated validations to run after merge: `python3 validate_production_ready.py`, `python3 -m pytest`, and targeted integration tests for the updater API and `aurora_backend` endpoints to confirm behavior under missing `AURORA_OPERATOR_SIGNING_KEY` and missing Aurora core.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69463fe690408325b91087d29ffed4b9)